### PR TITLE
art: Disable ART_HOST_CLANG on darwin builds.

### DIFF
--- a/build/Android.common_build.mk
+++ b/build/Android.common_build.mk
@@ -72,6 +72,12 @@ ART_TARGET_CFLAGS :=
 
 # Host.
 ART_HOST_CLANG := false
+
+ifeq ($(HOST_OS),darwin)
+  # Local darwin gcc is ancient
+  WITHOUT_HOST_CLANG ?= false
+endif
+
 ifeq ($(WITHOUT_HOST_CLANG),false)
   # By default, host builds use clang for better warnings.
   ART_HOST_CLANG := true


### PR DESCRIPTION
Change-Id: I9d34cfea13fe4e6902e02cfb9d2de7610ced878c
